### PR TITLE
Update for ROCm 6.0.0 compatibility.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -37,7 +37,7 @@ AC_ARG_WITH([libfabric],
              LDFLAGS="-L$withval/$ofi_libdir $LDFLAGS"],
             [])
 
-AC_DEFINE([__HIP_PLATFORM_HCC__], [], [Use HCC Platform])
+AC_DEFINE([__HIP_PLATFORM_AMD__], [], [Use HCC Platform])
 AC_ARG_WITH([hip],
             AC_HELP_STRING([--with-hip=PATH], [Path to non-standard HIP installation]),
             [AS_IF([test -d $withval/lib], [hip_libdir="lib"], [hip_libdir="lib64"])

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -494,7 +494,7 @@ static ncclResult_t get_cuda_device(void *data, int *device)
 		goto exit;
 	}
 
-	if (attr.memoryType == hipMemoryTypeDevice) {
+	if (attr.type == hipMemoryTypeDevice) {
 		cuda_device = attr.device;
 	}
 	else {


### PR DESCRIPTION
No issue.

*Description of changes:*

Use of `__HIP_PLATFORM_HCC__` has been deprecated for several releases of ROCm.  Replaced with `__HIP_PLATFORM_AMD__` as the former was removed in ROCm 6.0.0.

`hipPointerAttribute_t.memoryType` has been replaced by `hipPointerAttribute_t.type` as of ROCm 6.0.0.

With these two changes, I was able to build using ROCm 6.0.0.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
