### PR TITLE
Compatibility fix for 6.0.2

### DIFF
--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -494,7 +494,7 @@ static ncclResult_t get_cuda_device(void *data, int *device)
 		goto exit;
 	}
 
-	if (attr.memoryType == hipMemoryTypeDevice) {
+	if (attr.type == hipMemoryTypeDevice) {
 		cuda_device = attr.device;
 	}
 	else {


### PR DESCRIPTION
With change of hipPointerAttribute_t in 6.0.2, a change was required, changing variable name of struct from memoryType to type.

*Issue #, if available:*
#10 
*Description of changes:*
Small changes that make code compatible with 6.0.2. However, it is not clear to me how to generalise this change and ensure backward compatibility. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
