### PR TITLE
Update libfabric v2.0.0 compatibility

### DIFF
--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -36,6 +36,13 @@ extern "C" {
 #define MAX_PROV_INFO		(15)
 #define MAX_BDF_LEN		(25)
 
+/* Copied from libfabric:rdma/fabric.h@30ec628: "libfabric: Initial commit" */
+#ifndef container_of
+#define container_of(ptr, type, field) \
+	((type *) ((char *)ptr - offsetof(type, field)))
+#endif
+/* end of copied libfabric macros */
+
 /*
  * NCCL_NET_HANDLE_MAXSIZE is a limited resource (and defined in NCCL).
  * An endpoint address buffer of 56 bytes *should* be large enough to hold


### PR DESCRIPTION
resolves #13 

*Description of changes:*
Newer versions of libfabric are no longer defining this in "rdma/fabric.h", but we were relying on it transiently. Bring it in-tree to unblock compilation against libfabric master.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
