### PR TITLE
Add support for libfabric 2.0

### DIFF
--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -36,6 +36,13 @@ extern "C" {
 #define MAX_PROV_INFO		(15)
 #define MAX_BDF_LEN		(25)
 
+/* Copied from libfabric:rdma/fabric.h@30ec628: "libfabric: Initial commit" */
+#ifndef container_of
+#define container_of(ptr, type, field) \
+	((type *) ((char *)ptr - offsetof(type, field)))
+#endif
+/* end of copied libfabric macros */
+
 /*
  * NCCL_NET_HANDLE_MAXSIZE is a limited resource (and defined in NCCL).
  * An endpoint address buffer of 56 bytes *should* be large enough to hold

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -1198,7 +1198,6 @@ static ncclResult_t ofi_init(ncclDebugLogger_t logFunction)
 	NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "Selected Provider is %s",
 		      ofi_info_list->fabric_attr->prov_name);
 
-
 	/* Check if provider requires local memory registration */
 	if (ofi_info_list->domain_attr->mr_mode & FI_MR_LOCAL) {
 		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Provider %s requires registration of local memory buffers",

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -591,7 +591,7 @@ static void get_hints(struct fi_info *hints, int request_gdr)
 		 * Set MR mode bits to indicate that application allows
 		 * registration of both local and device memory buffers
 		 */
-		hints->domain_attr->mr_mode = FI_MR_ENDPOINT;
+		hints->domain_attr->mr_mode = FI_MR_ENDPOINT | FI_MR_HMEM;
 	}
 	else {
 		hints->caps = FI_TAGGED | FI_MSG | FI_REMOTE_COMM;
@@ -1170,6 +1170,7 @@ static ncclResult_t ofi_init(ncclDebugLogger_t logFunction)
 
 	/* Get list of NICs fi_info structures for a single provider */
 	ret = get_ofi_provider(prov_include, &ofi_info_list);
+
 	if (ret != 0 || ofi_info_list == NULL) {
 		ret = ncclSystemError;
 		goto exit;

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -199,7 +199,7 @@ static inline void zero_nccl_ofi_req(nccl_ofi_req_t *req)
 	req->rComm = NULL;
 
 	req->buffer_index = 0ULL;
-	memset(&req->ctx, 0, sizeof(struct fi_context));
+	memset(&req->ctx, 0, sizeof(req->ctx));
 
 	req->dev = -1;
 	req->size = 0;
@@ -602,7 +602,7 @@ static void get_hints(struct fi_info *hints, int request_gdr)
 		hints->domain_attr->mr_mode =FI_MR_ENDPOINT;
 	}
 
-	hints->mode = FI_CONTEXT;
+	hints->mode = FI_CONTEXT | FI_CONTEXT2;
 
 	hints->ep_attr->type = FI_EP_RDM;
 
@@ -690,7 +690,6 @@ static int get_ofi_provider(char *prov_include, struct fi_info **prov_info_list)
 	rc = find_ofi_provider(&providers);
 	if (rc != 0)
 		goto error;
-
 	/*
 	 * Create an array of providers where each index represents
 	 * a info structure list for a single provider name.
@@ -1112,7 +1111,7 @@ static inline ncclResult_t nccl_ofi_progress(nccl_ofi_t *nccl_ofi_comp)
 static ncclResult_t ofi_init(ncclDebugLogger_t logFunction)
 {
 	ncclResult_t ret = ncclSuccess;
-	char *prov_include = "cxi";
+	char *prov_include = "opx";
 	int idx, rc;
 
 	ofi_log_function = logFunction;
@@ -1199,6 +1198,7 @@ static ncclResult_t ofi_init(ncclDebugLogger_t logFunction)
 	NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "Selected Provider is %s",
 		      ofi_info_list->fabric_attr->prov_name);
 
+
 	/* Check if provider requires local memory registration */
 	if (ofi_info_list->domain_attr->mr_mode & FI_MR_LOCAL) {
 		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Provider %s requires registration of local memory buffers",
@@ -1208,7 +1208,6 @@ static ncclResult_t ofi_init(ncclDebugLogger_t logFunction)
 		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Provider %s does not require registration of local memory buffers",
 			       ofi_info_list->fabric_attr->prov_name);
 	}
-
 	/* Check if provider requires heterogeneous memory registration */
 	if (ofi_info_list->domain_attr->mr_mode & FI_MR_HMEM) {
 		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Provider %s requires registration of device buffers",


### PR DESCRIPTION
Copying this patch from upstream https://github.com/ROCm/aws-ofi-rccl/pull/14 which has yet to be merged. This gets us un-blocked and allows runs of aws-ofi-rccl and libfabric-internal main to work.