### PR TITLE
Updating readme to point users towards aws-ofi-nccl

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AWS OFI RCCL
+# AWS OFI RCCL is deprecated, please utilize upstream https://github.com/aws/aws-ofi-nccl which has support for ROCm + AMD GPUs
 
 AWS OFI RCCL is a plug-in which enables EC2 developers to use
 [libfabric](https://github.com/ofiwg/libfabric) as a network provider while


### PR DESCRIPTION
AWS's aws-ofi-nccl now has support for ROCm and AMD GPUs. See [here](https://github.com/aws/aws-ofi-nccl/commit/0d49b7aff88f453928cfe7a467463147333a4ced)

As this aws-ofi-rccl repository has not been updated in quite some time, I believe it is appropriate to mark this repo as deprecated and point users towards AWS's upstream repo.

Signed-off-by: Thomas Huber <thomas.huber@amd.com>